### PR TITLE
Increase fps when drawing the background

### DIFF
--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -26,6 +26,12 @@ let width = ($canvas.width = rect.width);
 let height = ($canvas.height = rect.height);
 let ctx = $canvas.getContext("2d");
 
+let buffer_canvas = document.createElement('canvas');
+buffer_canvas.width = canvas.width;
+buffer_canvas.height = canvas.height;
+let buffer_ctx = buffer_canvas.getContext("2d");
+
+
 // position of current screen
 let posX = 0;
 let posY = 0;
@@ -58,7 +64,7 @@ document.addEventListener('wheel', function(e) {
     } else if (e.deltaY < 0 && zoom < 10000) {
         zoom+=100;
     }
-    ctx.clearRect(0,0,$canvas.width,$canvas.height);
+    buffer_ctx.clearRect(0,0,$canvas.width,$canvas.height);
     draw();
 })
  */
@@ -68,10 +74,12 @@ function draw() {
   for (let x = 0; x < width; x += quality) {
     for (let y = 0; y < height; y += quality) {
       const seaLevel = calculateSeaLevel(x, y);
-      ctx.fillStyle = getColor(seaLevel);
-      ctx.fillRect(x, y, quality, quality);
+      buffer_ctx.fillStyle = getColor(seaLevel);
+      buffer_ctx.fillRect(x, y, quality, quality);
     }
   }
+
+  ctx.drawImage(buffer_canvas, 0, 0);
 }
 
 // Baseline sea level

--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -75,21 +75,33 @@ function draw() {
   const fixed_quality = quality
   
   for (let x = 0; x < width; x += fixed_quality) {
+    let last_color = "";
     for (let y = 0; y < height; y += fixed_quality) {
       const seaLevel = calculateSeaLevel(x, y);
       const color = getColor(seaLevel);
 
-      if (!drawing_batch.get(color)){
+      if (!drawing_batch.get(color)) {
         drawing_batch.set(color, [])
       }
 
-      drawing_batch.get(color).push({
-        x, y, delta_x: fixed_quality, delta_y: fixed_quality
-      })
+      if (last_color == color) {
+        const to_increase = drawing_batch.get(color).pop()
+        drawing_batch.get(color).push({
+          ...to_increase,
+          delta_y: to_increase.delta_y + fixed_quality
+        })
+      }
+      else {
+        drawing_batch.get(color).push({
+          x, y, delta_x: fixed_quality, delta_y: fixed_quality
+        })
+      }
+
+      last_color = color
     }
   }
 
-  for (let [color, squares] of drawing_batch){
+  for (let [color, squares] of drawing_batch) {
     buffer_ctx.fillStyle = color;
     for (let square of squares) {
       buffer_ctx.fillRect(square.x, square.y, square.delta_x, square.delta_y);

--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -71,11 +71,28 @@ document.addEventListener('wheel', function(e) {
 
 // Initial draw function
 function draw() {
-  for (let x = 0; x < width; x += quality) {
-    for (let y = 0; y < height; y += quality) {
+  const drawing_batch = new Map()
+  const fixed_quality = quality
+  
+  for (let x = 0; x < width; x += fixed_quality) {
+    for (let y = 0; y < height; y += fixed_quality) {
       const seaLevel = calculateSeaLevel(x, y);
-      buffer_ctx.fillStyle = getColor(seaLevel);
-      buffer_ctx.fillRect(x, y, quality, quality);
+      const color = getColor(seaLevel);
+
+      if (!drawing_batch.get(color)){
+        drawing_batch.set(color, [])
+      }
+
+      drawing_batch.get(color).push({
+        x, y, delta_x: fixed_quality, delta_y: fixed_quality
+      })
+    }
+  }
+
+  for (let [color, squares] of drawing_batch){
+    buffer_ctx.fillStyle = color;
+    for (let square of squares) {
+      buffer_ctx.fillRect(square.x, square.y, square.delta_x, square.delta_y);
     }
   }
 


### PR DESCRIPTION
Relates to Issue #33 .

Originally, running at quality 5 and moving, the fps was at about 37.4
![before_1](https://github.com/Glowstick0017/Little-Plane-Project/assets/16166854/fdd09ffe-b776-48cf-b2ff-327fb92885d5)

So i did a few changes:

1. The first change added a canvas off screen. So the screen doesn't need to be rendered for each pixel draw, only when the whole picture is finished. This increased the average fps in 12%.
![after_1](https://github.com/Glowstick0017/Little-Plane-Project/assets/16166854/42440e32-7592-4f2e-9d80-ad36b74df70b)

2. Went ahead and batched the drawing to happen for each color, avoiding having to change the canvas context too many times. This increased the average fps in 7%
![image](https://github.com/Glowstick0017/Little-Plane-Project/assets/16166854/78f163a1-209a-433f-8f67-736f171b1c6a)

3. As a last change, for every sequential line of the same color, we can draw a single rect, so I batched it again and increased the average fps in 149%.
![image](https://github.com/Glowstick0017/Little-Plane-Project/assets/16166854/014bdccd-ee26-4204-a98f-94be84f98aec)

Overall, with all those changes together the average fps increased in 197%. And just for show, here is a picture of the project running at quality 2.
![image](https://github.com/Glowstick0017/Little-Plane-Project/assets/16166854/ef35a486-209e-4d01-84cb-7110ce832e5a)
