### PR TITLE
Fixing color command

### DIFF
--- a/engine/Commands.js
+++ b/engine/Commands.js
@@ -64,13 +64,11 @@ const colorCommand = new Command("COLOR", "COLOR", 0, (args) => {
   if (color === 0) {
     color = 1;
     $color.innerHTML = "Color: " + color;
-    ctx.clearRect(0, 0, $canvas.width, $canvas.height);
     draw();
     return "Color on.";
   } else {
     color = 0;
     $color.innerHTML = "Color: " + color;
-    ctx.clearRect(0, 0, $canvas.width, $canvas.height);
     draw();
     return "Color off.";
   }

--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -73,7 +73,7 @@ document.addEventListener('wheel', function(e) {
 function draw() {
   const drawing_batch = new Map()
   const fixed_quality = quality
-  
+
   for (let x = 0; x < width; x += fixed_quality) {
     let last_color = "";
     for (let y = 0; y < height; y += fixed_quality) {
@@ -126,7 +126,8 @@ function calculateSeaLevel(x, y) {
 // Define terrain
 function getColor(seaLevel) {
   if (color === 0) {
-    return `rgba(0, 0, 0, ${seaLevel})`;
+    const gray_scale_range = (seaLevel * 255).toFixed();
+    return `rgb(${gray_scale_range}, ${gray_scale_range}, ${gray_scale_range})`;
   } else {
     return terrainColor(seaLevel);
   }


### PR DESCRIPTION
Fixes #38 , caused by #36 (my bad). Tested all the commands this time to make sure nothing else was impacted xD. 

Sadly running with colors off the performance isn't as good as running it with colors on due to the increase in the variability of each pixel. The terrain color mapping really helps out with performance.