### PR TITLE
Fix to glitching pixel bars on window sides

### DIFF
--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -65,9 +65,9 @@ function draw() {
   const drawing_batch = new Map()
   const fixed_quality = quality
 
-  for (let x = 0; x < width; x += fixed_quality) {
+  for (let x = -fixed_quality; x < width + fixed_quality; x += fixed_quality) {
     let last_color = "";
-    for (let y = 0; y < height; y += fixed_quality) {
+    for (let y = -fixed_quality; y < height + fixed_quality; y += fixed_quality) {
       const seaLevel = calculateSeaLevel(x, y);
       const color = getColor(seaLevel);
 


### PR DESCRIPTION
Just a quick solution to the buggy pixels being drawn on the edges that I introduced. Bit of a hack, just draws an extra row of pixels on each side. But did seem to work on my end.