### PR TITLE
Altitude Zooming Changes

### DIFF
--- a/engine/Controls.js
+++ b/engine/Controls.js
@@ -29,12 +29,16 @@ let minSpeed = 0.5;
 let maxSpeed = 1.5;
 let throttlePower = 0.5;
 
+// altitude based
+let minHeight = 50;
+let maxHeight = 500;
+let altSpeed = 1;
+
 //update dx and dy based on player angle
 const updateDirection = () => {
     dx = Math.cos(playerAngle);
     dy = Math.sin(playerAngle);
 }
-
 
 // Defining constants for keys to improve readability
 const KEYS = {
@@ -46,8 +50,8 @@ const KEYS = {
     ARROW_DOWN: 'ArrowDown',
     ARROW_LEFT: 'ArrowLeft',
     ARROW_RIGHT: 'ArrowRight',
-    U: "u",
-    J: "j",
+    U: "[",
+    J: "]",
     ToggleForward: 'e',
 };
 
@@ -57,25 +61,36 @@ document.addEventListener("keyup", deregisterKeyPress);
 
 // Handler for key press events
 function registerKeyPress(e) {
-  if (handler.isFocused) return; // Makes sure commands aren't being typed
-  keysPressed[formatKey(e.key)] = true;
+    if (handler.isFocused) return; // Makes sure commands aren't being typed
+    keysPressed[formatKey(e.key)] = true;
 }
 
 // Handler for key release events
 function deregisterKeyPress(e) {
-  keysPressed[formatKey(e.key)] = false;
+    keysPressed[formatKey(e.key)] = false;
 }
 
 function formatKey(key) {
-  return key.startsWith("Arrow") ? key : key.toLowerCase();
+    return key.startsWith("Arrow") ? key : key.toLowerCase();
+}
+
+function smooth(value, quality) {
+    return Math.round(value / quality) * quality;
 }
 
 // Elevate the sea level
 function elevateHeight(dz) {
-  heightFromGround += dz;
+    oldHeight = heightFromGround;
+    heightFromGround += dz;
 
-  // Set the flag to redraw the canvas
-  needsRedraw = true;
+    heightFromGround = clamp(heightFromGround, minHeight, maxHeight);
+
+    // adjust the position of the plane based on the new height
+    posX = smooth((posX * heightFromGround) / oldHeight, quality);
+    posY = smooth((posY * heightFromGround) / oldHeight, quality);
+
+    // Set the flag to redraw the canvas
+    needsRedraw = true;
 }
 
 function clamp(value, min, max) {
@@ -188,10 +203,10 @@ function gameLoop() {
     }
 
     if(keysPressed[KEYS.U]){
-        elevateHeight(-1);
+        elevateHeight(-altSpeed);
     }
     else if(keysPressed[KEYS.J]){
-        elevateHeight(1);
+        elevateHeight(altSpeed);
     }
 
     moveRotate(dx, dy , keyPressedFlag)

--- a/engine/Controls.js
+++ b/engine/Controls.js
@@ -30,8 +30,8 @@ let maxSpeed = 1.5;
 let throttlePower = 0.5;
 
 // altitude based
-let minHeight = 50;
-let maxHeight = 500;
+let minAltitude = 50;
+let maxAltitude = 500;
 let altSpeed = 1;
 
 //update dx and dy based on player angle
@@ -79,15 +79,15 @@ function smooth(value, quality) {
 }
 
 // Elevate the sea level
-function elevateHeight(dz) {
-    oldHeight = heightFromGround;
-    heightFromGround += dz;
+function elevateAltitude(dz) {
+    oldAltitude = altitudeFromGround;
+    altitudeFromGround += dz;
 
-    heightFromGround = clamp(heightFromGround, minHeight, maxHeight);
+    altitudeFromGround = clamp(altitudeFromGround, minAltitude, maxAltitude);
 
     // adjust the position of the plane based on the new height
-    posX = smooth((posX * heightFromGround) / oldHeight, quality);
-    posY = smooth((posY * heightFromGround) / oldHeight, quality);
+    posX = smooth((posX * altitudeFromGround) / oldAltitude, quality);
+    posY = smooth((posY * altitudeFromGround) / oldAltitude, quality);
 
     // Set the flag to redraw the canvas
     needsRedraw = true;
@@ -203,10 +203,10 @@ function gameLoop() {
     }
 
     if(keysPressed[KEYS.U]){
-        elevateHeight(-altSpeed);
+        elevateAltitude(-altSpeed);
     }
     else if(keysPressed[KEYS.J]){
-        elevateHeight(altSpeed);
+        elevateAltitude(altSpeed);
     }
 
     moveRotate(dx, dy , keyPressedFlag)

--- a/engine/Controls.js
+++ b/engine/Controls.js
@@ -50,8 +50,8 @@ const KEYS = {
     ARROW_DOWN: 'ArrowDown',
     ARROW_LEFT: 'ArrowLeft',
     ARROW_RIGHT: 'ArrowRight',
-    U: "[",
-    J: "]",
+    LT_SQ_BRACKET: "[",
+    RT_SQ_BRACKET: "]",
     ToggleForward: 'e',
 };
 
@@ -85,7 +85,7 @@ function elevateAltitude(dz) {
 
     altitudeFromGround = clamp(altitudeFromGround, minAltitude, maxAltitude);
 
-    // adjust the position of the plane based on the new height
+    // adjust the position of the plane based on the new altitude
     posX = smooth((posX * altitudeFromGround) / oldAltitude, quality);
     posY = smooth((posY * altitudeFromGround) / oldAltitude, quality);
 
@@ -202,10 +202,10 @@ function gameLoop() {
         }
     }
 
-    if(keysPressed[KEYS.U]){
+    if(keysPressed[KEYS.LT_SQ_BRACKET]){
         elevateAltitude(-altSpeed);
     }
-    else if(keysPressed[KEYS.J]){
+    else if(keysPressed[KEYS.RT_SQ_BRACKET]){
         elevateAltitude(altSpeed);
     }
 

--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -34,7 +34,6 @@ buffer_canvas.width = canvas.width;
 buffer_canvas.height = canvas.height;
 let buffer_ctx = buffer_canvas.getContext("2d");
 
-
 // position of current screen
 let posX = 0;
 let posY = 0;
@@ -98,7 +97,12 @@ function draw() {
   for (let [color, squares] of drawing_batch) {
     buffer_ctx.fillStyle = color;
     for (let square of squares) {
-      buffer_ctx.fillRect(square.x - drawOffsetX, square.y - drawOffsetY, square.delta_x, square.delta_y);
+      buffer_ctx.fillRect(
+        square.x - drawOffsetX,
+        square.y - drawOffsetY,
+        square.delta_x,
+        square.delta_y
+      );
     }
   }
 
@@ -109,11 +113,20 @@ function draw() {
 function calculateSeaLevel(x, y) {
   // set values to variables so they can be adjusted (by slider?)
   let mountainHeight = 1.0; // nice visual range: 0 - 1.3
+  
+  let roundedPosX = Math.round(posX / quality) * quality;
+  let roundedPosY = Math.round(posY / quality) * quality;
+
+  let adjustedX = roundedPosX - (width / 2);
+  let adjustedY = roundedPosY - (height / 2);
 
   return (
-    (perlin2((x + (Math.round(posX/quality)*quality)) / heightFromGround, (y + (Math.round(posY/quality)*quality)) / heightFromGround) +
-      mountainHeight) /
-    2
+    (
+      perlin2(
+        (x + adjustedX) / heightFromGround,
+        (y + adjustedY) / heightFromGround
+      ) + mountainHeight
+    ) / 2
   );
 }
 

--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -37,7 +37,7 @@ let buffer_ctx = buffer_canvas.getContext("2d");
 // position of current screen
 let posX = 0;
 let posY = 0;
-let heightFromGround = 300; // nice visual range: 250 - 500
+let altitudeFromGround = 300; // nice visual range: 250 - 500
 $coordinates.innerHTML = "Coordinates: X=" + posX + ", Y=" + posY;
 
 // block size by pixel, i wouldn't recommend going under 5, load times will be longer
@@ -123,8 +123,8 @@ function calculateSeaLevel(x, y) {
   return (
     (
       perlin2(
-        (x + adjustedX) / heightFromGround,
-        (y + adjustedY) / heightFromGround
+        (x + adjustedX) / altitudeFromGround,
+        (y + adjustedY) / altitudeFromGround
       ) + mountainHeight
     ) / 2
   );


### PR DESCRIPTION
# Changelog
- Plane changes altitude relatively now - the map zooms from the position of plane not the canvas top left to bottom right
- Controls for altitudes switched to `[` and `]` keys
- Altitude speed can now be controlled
- Minimum and maximum altitudes for the plane
- Minor refactors

# Missing in this update
- Commands to set minimum and maximum altitudes
- Command to set altitude
- Command to set altitude speed